### PR TITLE
Don't type site_settings variable to a map due to mixed value types

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -124,6 +124,6 @@ variable "rules_cache_timeout" {
 }
 
 variable "site_settings" {
-  type        = map(any)
+  #type        = map(any)
   description = "A map of site settings that represent user-configurable parameters"
 }


### PR DESCRIPTION
Don't type site_settings variable to a map due to mixed value types