### PR TITLE
Switch from x-frame-options to content-security-policy to enable frame-ancestors

### DIFF
--- a/LambdaEdgeFunctions/security/index.js
+++ b/LambdaEdgeFunctions/security/index.js
@@ -9,7 +9,8 @@ module.exports.handler = (event, context, callback) => {
     headers['strict-transport-security'] = [{ key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubdomains; preload' }];
     //headers['content-security-policy'] = [{key: 'Content-Security-Policy', value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"}]; 
     headers['x-content-type-options'] = [{ key: 'X-Content-Type-Options', value: 'nosniff' }];
-    headers['x-frame-options'] = [{ key: 'X-Frame-Options', value: 'DENY' }];
+    //headers['x-frame-options'] = [{ key: 'X-Frame-Options', value: 'DENY' }];
+    headers['content-security-policy'] = [{ key: 'Content-Security-Policy', value: 'frame-ancestors \'self\' https://*.tamu.edu' }];
     headers['x-xss-protection'] = [{ key: 'X-XSS-Protection', value: '1; mode=block' }];
     headers['referrer-policy'] = [{ key: 'Referrer-Policy', value: 'same-origin' }];
 


### PR DESCRIPTION
- Switch the security headers lambda away from x-frame-options header in favor of the content-security-policy header, and enable tamu-based origins to use frame-ancestors (to enable site embedding).