### PR TITLE
Fix cert replacement using create_before_destroy, and fix validation dependancy

### DIFF
--- a/certs.tf
+++ b/certs.tf
@@ -17,6 +17,10 @@ resource "aws_acm_certificate" "cert" {
   domain_name               = local.domain
   subject_alternative_names = local.sans
   validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Cert validation entries for anything with a route53 address

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -502,6 +502,10 @@ resource "aws_cloudfront_distribution" "site" {
       restriction_type = "none"
     }
   }
+
+  depends_on = [ 
+    aws_acm_certificate_validation.cert 
+  ]
 }
 
 


### PR DESCRIPTION
- Enable certs to be replaced without downtime by using create_before_destroy lifecycle property
- Fix validation error where terraform would attempt CloudFront distribution creation before ACM cert had been validated