### PR TITLE
Remove bucket ACL for public site; we already have a policy

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -13,10 +13,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "public-read"
-}
+#resource "aws_s3_bucket_acl" "bucket" {
+#  bucket = aws_s3_bucket.bucket.id
+#  acl    = "public-read"
+#}
 
 resource "aws_s3_bucket_website_configuration" "bucket" {
   bucket = aws_s3_bucket.bucket.id


### PR DESCRIPTION
- Remove public-read ACL as per new recommendations. The ACL was unneeded anyway because the bucket policy was already making the bucket public.