### PR TITLE
Get rid of ACL for default test content

### DIFF
--- a/test_content.tf
+++ b/test_content.tf
@@ -16,7 +16,7 @@ EOF
 resource "aws_s3_object" "test_index" {
   bucket       = aws_s3_bucket.bucket.bucket
   key          = "index.html"
-  acl          = "public-read"
+  #acl          = "public-read"
   content      = local.test_index
   content_type = "text/html"
 


### PR DESCRIPTION
- Get rid of the ACL used when uploading the default test content HTML file