### PR TITLE
Enable lambda rewrites for index.html for hostname-based redirect sites

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -116,6 +116,42 @@ resource "aws_cloudfront_distribution" "site" {
       }
     }
 
+    # We don't normally do rewrites on index files, but in the case of a hostname-based
+    # redirect site, we need to
+    dynamic "lambda_function_association" {
+      for_each = local.enable_hostname_rewrites ? toset([0]) : toset([])
+
+      content {
+        event_type   = "origin-request"
+        lambda_arn   = aws_lambda_function.edge_rewrite.qualified_arn
+        include_body = false
+      }
+    }
+
+    # We don't normally do rewrites on index files, but in the case of a hostname-based
+    # redirect site, we need to
+    dynamic "lambda_function_association" {
+      for_each = local.enable_hostname_rewrites ? toset([0]) : toset([])
+
+      content {
+        event_type   = "origin-response"
+        lambda_arn   = aws_lambda_function.edge_security.qualified_arn
+        include_body = false
+      }
+    }
+
+    # We don't normally do rewrites on index files, but in the case of a hostname-based
+    # redirect site, we need to
+    dynamic "lambda_function_association" {
+      for_each = local.enable_hostname_rewrites ? toset([0]) : toset([])
+
+      content {
+        event_type   = "viewer-request"
+        lambda_arn   = aws_lambda_function.edge_host_header[0].qualified_arn
+        include_body = false
+      }
+    }
+
     min_ttl                = try(var.site_settings.index_ttl, var.index_ttl)
     default_ttl            = try(var.site_settings.index_ttl, var.index_ttl)
     max_ttl                = try(var.site_settings.index_ttl, var.index_ttl)


### PR DESCRIPTION
- Enable Lambda@Edge rewrites for index.html so that hostname-based redirect sites will work. This is only activated if the hostname redirect feature is turned on.