### PR TITLE
Add depends_on clause for s3 bucket public policy

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -117,4 +117,8 @@ resource "aws_s3_bucket_policy" "site_bucket_policy" {
         }
       ]
   })
+
+  depends_on = [
+    aws_s3_bucket_public_access_block.bucket
+  ]
 }


### PR DESCRIPTION
- Fix issue where public bucket access policy was applied before unblocking public access by adding depends_on.